### PR TITLE
Fix error with service cpu and memory values

### DIFF
--- a/ecs_chargeback/lib/cluster.py
+++ b/ecs_chargeback/lib/cluster.py
@@ -36,10 +36,23 @@ class Cluster:
                         taskDefinition=ecs_service["taskDefinition"]
                     )["taskDefinition"]
 
-                    cpu, memory = 0, 0
+                    task_cpu = int(task_definition.get("cpu", 0))
+                    task_memory = int(task_definition.get("memory", 0))
+
+                    container_cpu, container_memory = 0, 0
                     for container in task_definition["containerDefinitions"]:
-                        cpu += container["cpu"]
-                        memory += container["memory"]
+                        container_cpu += int(container.get("cpu", 0))
+                        container_memory += int(container.get("memory", 0))
+
+                    if task_cpu and task_cpu >= container_cpu:
+                        cpu = task_cpu
+                    else:
+                        cpu = container_cpu
+
+                    if task_memory and task_memory >= container_memory:
+                        memory = task_memory
+                    else:
+                        memory = container_memory
 
                     tags = []
                     try:

--- a/ecs_chargeback/requirements.txt
+++ b/ecs_chargeback/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.16.44
-tabulate==0.8.7
+boto3==1.26.52
+tabulate==0.9.0
 datadog

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -11,6 +11,7 @@ from aws_cdk import (
     aws_s3,
     aws_iam,
 )
+from gaggle_cdk.core import apply_permissions_boundary
 
 base_path = dirname(dirname(abspath(__file__)))
 
@@ -46,7 +47,7 @@ class ChargebackStack(cdk.Stack):
             self,
             "ChargebackHandler",
             entry=join(base_path, "ecs_chargeback"),
-            runtime=aws_lambda.Runtime.PYTHON_3_7,
+            runtime=aws_lambda.Runtime.PYTHON_3_8,
             index="lambda.py",
             handler="handler",
             environment={
@@ -105,5 +106,7 @@ ChargebackStack(
         region=os.environ["CDK_DEFAULT_REGION"],
     ),
 )
+
+apply_permissions_boundary(app)
 
 app.synth()

--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,3 +1,4 @@
-aws-cdk-lib==2.15.0
-aws_cdk.aws_lambda_python_alpha==2.15.0a0
+aws-cdk-lib==2.61.0
+aws_cdk.aws_lambda_python_alpha==2.61.0a0
 constructs>=10.0.0
+gaggle-cdk.core==2.1.164


### PR DESCRIPTION
This PR fixes an error with the lambda function when grabbing cpu and memory values for a given ECS task definition. Since task-level values and container-level values are optional depending on which one is set, this fix grabs the available value and sets overall value appropriately depending on which was available.